### PR TITLE
Adding --strict=0 option to userDelete() for drupal6 compatibility.

### DIFF
--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -142,6 +142,7 @@ class DrushDriver extends BaseDriver {
     $options = array(
       'yes' => NULL,
       'delete-content' => NULL,
+      'strict' => 0,
     );
     $this->drush('user-cancel', $arguments, $options);
   }


### PR DESCRIPTION
I was getting RuntimeExceptions while testing on a Drupal 6 site when creating a user.

```
Scenario: Project list home page                               # features/project.list.feature:7
    Given I am logged in as a user with the "administrator" role # Drupal\DrupalExtension\Context\DrupalContext::assertAuthenticatedByRole()
 │
  ╳  Unknown option: --delete-content.  See `drush help user-cancel` for  [error]
  ╳  available options. To suppress this error, add the option --strict=0.
  ╳   (RuntimeException)
  │
  └─ @AfterScenario # 

```

I tracked it down to userDelete.  If I add "strict" it works!
